### PR TITLE
Move distortion metrics to embedding.metric module

### DIFF
--- a/tests/embedding/metric/test_distortion_metrics.py
+++ b/tests/embedding/metric/test_distortion_metrics.py
@@ -18,7 +18,7 @@ class TestDistortionMetrics(unittest.TestCase):
 
         expected_mean_avg_precision = 0.9583
 
-        calculated_mean_avg_precision = tc.embedding.distortion_metrics.mean_average_precision(graph, emb_container)
+        calculated_mean_avg_precision = tc.embedding.metric.distortion_metrics.mean_average_precision(graph, emb_container)
 
         self.assertAlmostEqual(expected_mean_avg_precision, calculated_mean_avg_precision, places=4)
 
@@ -26,8 +26,8 @@ class TestDistortionMetrics(unittest.TestCase):
         embedding_container = tc.embedding.EmbeddingContainer(embedding=[[0]], vertex_labels=[0])
 
         with self.assertRaises(ValueError):
-            tc.embedding.distortion_metrics.mean_average_precision(None, embedding_container)
+            tc.embedding.metric.distortion_metrics.mean_average_precision(None, embedding_container)
 
     def test_mean_average_precision_embedding_not_specified_error_raised(self):
         with self.assertRaises(ValueError):
-            tc.embedding.distortion_metrics.mean_average_precision(nx.Graph(), None)
+            tc.embedding.metric.distortion_metrics.mean_average_precision(nx.Graph(), None)

--- a/tests/embedding/metric/test_distortion_metrics.py
+++ b/tests/embedding/metric/test_distortion_metrics.py
@@ -18,7 +18,10 @@ class TestDistortionMetrics(unittest.TestCase):
 
         expected_mean_avg_precision = 0.9583
 
-        calculated_mean_avg_precision = tc.embedding.metric.distortion_metrics.mean_average_precision(graph, emb_container)
+        calculated_mean_avg_precision = tc.embedding.metric.distortion_metrics.mean_average_precision(
+            graph,
+            emb_container
+        )
 
         self.assertAlmostEqual(expected_mean_avg_precision, calculated_mean_avg_precision, places=4)
 

--- a/topologic/embedding/__init__.py
+++ b/topologic/embedding/__init__.py
@@ -10,7 +10,6 @@ from .laplacian_spectral_embedding import laplacian_embedding
 from .omnibus_embedding import omnibus_embedding, generate_omnibus_matrix
 from .pca import pca
 from .tsne import tsne
-from .distortion_metrics import mean_average_precision
 from .node2vec_walk import node2vec_random_walk_iterator
 
 from . import clustering
@@ -23,7 +22,6 @@ __all__ = [
     'SampleMethod',
     'adjacency_embedding',
     'generate_omnibus_matrix',
-    'mean_average_precision',
     'laplacian_embedding',
     'node2vec_embedding',
     'node2vec_random_walk_iterator',

--- a/topologic/embedding/metric/__init__.py
+++ b/topologic/embedding/metric/__init__.py
@@ -1,10 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from .procrustes import procrustes_error
 from .density import calculate_internal_external_densities
+from .distortion_metrics import mean_average_precision
+from .procrustes import procrustes_error
 
 __all__ = [
     'calculate_internal_external_densities',
+    'mean_average_precision',
     'procrustes_error'
 ]

--- a/topologic/embedding/metric/distortion_metrics.py
+++ b/topologic/embedding/metric/distortion_metrics.py
@@ -4,7 +4,7 @@
 import networkx as nx
 import numpy as np
 from scipy.spatial.distance import cdist
-from .embedding_container import EmbeddingContainer
+from topologic.embedding.embedding_container import EmbeddingContainer
 
 
 def mean_average_precision(

--- a/topologic/embedding/metric/distortion_metrics.py
+++ b/topologic/embedding/metric/distortion_metrics.py
@@ -4,7 +4,7 @@
 import networkx as nx
 import numpy as np
 from scipy.spatial.distance import cdist
-from topologic.embedding.embedding_container import EmbeddingContainer
+from ..embedding_container import EmbeddingContainer
 
 
 def mean_average_precision(


### PR DESCRIPTION
Distortion metrics should not live in the root of the embedding package but inside the metrics package.