### PR TITLE
"Fixing" topologic documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon'
 ]
 
 

--- a/docs/topologic.embedding.rst
+++ b/docs/topologic.embedding.rst
@@ -6,6 +6,14 @@ topologic.embedding package
    :undoc-members:
    :show-inheritance:
 
+topologic.embedding modules
+=============================
+
+.. automodule:: topologic.embedding.distance
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Subpackages
 -----------
 

--- a/docs/topologic.partition.rst
+++ b/docs/topologic.partition.rst
@@ -5,26 +5,3 @@ topologic.partition package
    :members:
    :undoc-members:
    :show-inheritance:
-   :exclude-members: louvain
-
-.. function:: topologic.partition.louvain(graph: networkx.classes.graph.Graph, partition=Optional[Dict[Any, int]]=None, \
-        weight: str='weight', resolution: float=1.0, randomize: Optional[bool]=None, random_state: Optional[Any]=None)
-
-    This louvain function is an alias to the `community.best_partition <https://python-louvain.readthedocs.io/en/latest/api.html#community.best_partition>`_ function
-    in the `python-louvain <https://github.com/taynaud/python-louvain>`_ library written by `Thomas Aynaud <https://github.com/taynaud>`_.
-
-    :param networkx.Graph graph: the networkx graph which is decomposed
-    :param partition: the algorithm will start using this partition of the nodes. It's a
-        dictionary where keys are their nodes and values the communities
-    :type partition: Optional[Dict[Any, int]]
-    :param str weight_attribute: the key in graph to use as weight. Default to 'weight'
-    :param float resolution: Will change the size of the communities, default to 1. represents the time described in
-        "Laplacian Dynamics and Multiscale Modular Structure in Networks", R. Lambiotte, J.-C. Delvenne, M. Barahona
-    :param Any random_state: If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
-    :return: The partition, with communities numbered from 0 to number of communities
-    :rtype: Dict[Any, int]
-    :raises: NetworkXError - If the graph is not Eulerian.
-

--- a/docs/topologic.rst
+++ b/docs/topologic.rst
@@ -6,6 +6,13 @@ topologic package
    :undoc-members:
    :show-inheritance:
 
+topologic modules
+===================
+.. automodule:: topologic.similarity
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Subpackages
 -----------
 

--- a/topologic/embedding/__init__.py
+++ b/topologic/embedding/__init__.py
@@ -16,18 +16,19 @@ from .sample_methods import SampleMethod, sample_graph_by_edge_weight, sample_gr
 from .tsne import tsne
 
 __all__ = [
+    'adjacency_embedding',
+    'distance',
     'EmbeddingContainer',
     'EmbeddingMethod',
-    'OutOfSampleEmbeddingContainer',
-    'SampleMethod',
-    'adjacency_embedding',
     'find_elbows',
     'generate_omnibus_matrix',
     'laplacian_embedding',
     'node2vec_embedding',
     'omnibus_embedding',
+    'OutOfSampleEmbeddingContainer',
     'pca',
     'sample_graph_by_edge_weight',
     'sample_graph_by_vertex_degree',
+    'SampleMethod',
     'tsne'
 ]

--- a/topologic/embedding/distance.py
+++ b/topologic/embedding/distance.py
@@ -1,8 +1,3 @@
-"""
-The distance module has aliased 2 functions that come from `Scipy <https://docs.scipy.org>`_,
-`cosine <https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cosine.html>`_,
-and `euclidean <https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.euclidean.html>`_
-"""
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
@@ -23,9 +18,15 @@ __all__ = [
 
 
 cosine = spatial.distance.cosine
+cosine.__doc__ = f"{spatial.distance.cosine.__doc__.replace('scipy.spatial', 'topologic.embedding')}\n\n    " \
+    f"This function is an alias for " \
+    f"`scipy.spatial.distance.cosine <https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cosine.html>`_."
 
 
 euclidean = spatial.distance.euclidean
+euclidean.__doc__ = f"{spatial.distance.euclidean.__doc__.replace('scipy.spatial', 'topologic.embedding')}\n\n    " \
+    f"This function is an alias for " \
+    f"`scipy.spatial.distance.euclidean <https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.euclidean.html>`_."
 
 
 def mahalanobis(inverse_covariance: np.ndarray) -> Callable[[np.ndarray, np.ndarray], float]:
@@ -85,6 +86,7 @@ def vector_distance(
     Vector distance is a function that will do any distance function you would like on two vectors. This is most
     commonly used by changing the method parameter, as a string, from "cosine" to "euclidean" - allowing you to change
     your flow based on configuration not on code changes to the actual cosine and euclidean functions.
+
     :param np.ndarray first_vector: A 1d array-like (list, tuple, np.array) that represents the first vector
     :param np.ndarray second_vector: A 1d array-like (list, tuple, np.array) that represents the second vector
     :param method: Method can be any distance function that takes in 2 parameters. It can also be the string mapping
@@ -113,8 +115,9 @@ def embedding_distances_from(
 
     :param np.ndarray vector: A 1d array-like (list, tuple, np.array) that represents the vector to compare against
         every other vector in the embedding
-    :param Union[EmbeddingContainer, np.ndarray] embedding: The embedding is either a 2d np array, where each row is
+    :param embedding: The embedding is either a 2d np array, where each row is
         a vector and the number of columns is identical to the length of the vector to compare against.
+    :type embedding: Union[EmbeddingContainer, np.ndarray]
     :param method: Method can be any distance function that takes in 2 parameters. It can also be the string mapping
         to that function (as described by valid_distance_functions()). Note that you can also provide other functions,
         such as `mahalanobis`, but they require more information than just the comparative vectors.

--- a/topologic/partition/louvain_stub.py
+++ b/topologic/partition/louvain_stub.py
@@ -4,5 +4,23 @@
 import community
 
 
+_fixed_best_partition_docstring = community.best_partition.__doc__.replace(
+    "community.best_partition",
+    "topologic.partition.louvain"
+).replace(
+    "community(",
+    "louvain("
+).replace(
+    ".. 1.",
+    "1."
+).replace(
+    "Uses Louvain algorithm",
+    "This louvain function is an alias to the " \
+    "`community.best_partition <https://python-louvain.readthedocs.io/en/latest/api.html#community.best_partition>`_ function" \
+    " in the `python-louvain <https://github.com/taynaud/python-louvain>`_ library written by " \
+    "`Thomas Aynaud <https://github.com/taynaud>`_. "
+)
+
 # Documentation note: see docs/topologic.partition.rst for document string to louvain function alias
 louvain = community.best_partition
+louvain.__doc__ = _fixed_best_partition_docstring


### PR DESCRIPTION
This is a work in progress and I'm honestly not convinced it's the right way to handle this in the first place.

`topologic` is kind of taking an interesting position as a 'library that
includes the best python libraries for building, manipulating, and
understanding graphs - along with some tlc and novel embedding
approaches'. In some cases, there's just no need for us to reinvent the
wheel - for instance, the spatial distance functions in scipy are fine,
and there's no use in us writing our own. A python louvain
implementation already exists and it's reasonably fast, so why build our
own?

However, we have opinions on which functions and implementations are the best,
and want to make it *easy* for those doing graph analysis to use these
best implementations without having to do their own research. So we have
basically two options:
- simply alias these functions as if they belong to topologic, so they
are easily discoverable and users new to this space can get moving
quicker without hunting around for a function (or worse, rolling their
own without looking)
- create function stubs in topologic with our own documentation and call
these functions without really doing anything.

In the former case, we need to update their documentation, so that their
examples refer to the topologic namespace, or fix their documentation
so that Sphinx won't throw a warning (which is a validation failure to
our merge/release process).

The problem with this is that we're achieving it through string
replacement on the doc strings, and if their documentation changes
enough our replacements are going to make no sense (or introduce
errors). This won't harm our published library or documentation, but it
will be inconsistent at runtime for any downstream users who have done a
fresh pip install of our library and maybe got a newer version of scipy
or python-louvain that introduces new docstrings, arguments, etc, that
break our patched doc string replacement routines and thus break help().

In the latter case, we're adding a bunch of code that ... doesn't really
do anything on its own, besides define a method signature with clear
documentation that we maintain and then call their library.

And perhaps the biggest problem both of these share is that we're
implying we're doing something important when the reality is we're just
curating the best functions for the common but vital tasks we use in our
daily work with network analysis.

In conclusion, I am not convinced this is the right commit, but it's far
enough along I want others to take a look.