### PR TITLE
topologic.io.from_dataset ignoring empty directed graphs and creating undirected instead

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.1.1
+- [Issue 29](https://github.com/microsoft/topologic/issues/29) Fixed bug in `topologic.io.from_dataset` where an empty networkx graph object (Graph, DiGraph, etc) was being treated as if no networkx Graph object were provided at all.
+- Added `is_digraph` parameter to `topologic.io.from_file`. This parameter defaults to False for original behavior. Setting it to True will create a networkx DiGraph object instead.
+
 ## 0.1.0
 - Initial release
 

--- a/tests/io/test_csv_loader.py
+++ b/tests/io/test_csv_loader.py
@@ -4,6 +4,7 @@
 import unittest
 
 import csv
+import networkx as nx
 from topologic.io import CsvDataset, from_dataset, from_file, load
 from topologic import projection
 from ..utils import data_file
@@ -140,6 +141,15 @@ class TestCsvLoaderFromDataset(unittest.TestCase):
                 {"lastName": "redhot", "sandwichPreference": "buffalo chicken"},
                 graph.nodes["frank"]["attributes"][0]
             )
+
+    def test_digraph_from_dataset(self):
+        digraph = nx.DiGraph()
+        with open(data_file("tiny-graph.csv")) as edge_file:
+            dataset = CsvDataset(edge_file, True, "excel")
+            proj = projection.edge_ignore_metadata(1, 2, 4)
+            graph = from_dataset(dataset, proj, digraph)
+
+        self.assertEqual(digraph, graph)
 
 
 class TestCsvLoaderFromFile(unittest.TestCase):
@@ -313,3 +323,16 @@ class TestCsvLoaderFromFile(unittest.TestCase):
                     {"lastName": "redhot", "sandwichPreference": "buffalo chicken"},
                     graph.nodes["frank"]["attributes"][0]
                 )
+
+    def test_digraph_from_file(self):
+        with open(data_file("tiny-graph.csv")) as edge_file:
+            graph = from_file(
+                edge_csv_file=edge_file,
+                source_column_index=1,
+                target_column_index=2,
+                weight_column_index=4,
+                edge_csv_has_headers=True,
+                is_digraph=True
+            )
+
+        self.assertTrue(graph.is_directed())

--- a/topologic/io/csv_loader.py
+++ b/topologic/io/csv_loader.py
@@ -45,7 +45,7 @@ def from_dataset(
     :return: the graph object
     :rtype: nx.Graph
     """
-    if not graph:
+    if graph is None:
         graph = nx.Graph()
 
     projection_function = projection_function_generator(graph)
@@ -72,7 +72,8 @@ def from_file(
     vertex_csv_use_headers: Optional[List[str]] = None,
     vertex_metadata_behavior: str = "single",
     vertex_ignored_values: Optional[List[str]] = None,
-    sample_size: int = 50
+    sample_size: int = 50,
+    is_digraph: bool = False,
 ) -> nx.Graph:
     """
     This function weaves a lot of graph materialization code into a single call.
@@ -160,6 +161,7 @@ def from_file(
         Please note that this sample_size does NOT advance your underlying iterator, nor is there any guarantee that
         the csv Sniffer class will use every row extracted via sample_size.  Setting this above 50 may not have the
         impact you hope for due to the csv.Sniffer.has_header function - it will use at most 20 rows.
+    :param bool is_digraph: If the data represents an undirected graph or a directed graph. Default is `False`.
     :return: The graph populated graph
     :rtype: nx.Graph
     """
@@ -197,7 +199,8 @@ def from_file(
     if edge_projection_function is None:
         raise ValueError('edge_metadata_behavior must be "none", "collection", or "single"')
 
-    graph = from_dataset(edge_dataset, edge_projection_function)
+    graph = nx.DiGraph() if is_digraph else nx.Graph()
+    graph = from_dataset(edge_dataset, edge_projection_function, graph)
 
     if vertex_csv_file:
         if vertex_column_index is None:


### PR DESCRIPTION
The `from_dataset` function was doing a truthiness check on the graph object, instead of specifically testing for Noneness. This meant that our tests and behaviors around *enriching already populated graph objects* was working fine, but it also meant that we would fail in situations where a fresh nx.Graph or nx.DiGraph object were to be passed in instead - and fail by ignoring them and creating a new graph entirely.

This would be very subtle to find, since most of our tests around around undirected graphs and we wouldn't notice an empty nx.Graph not being used in favor of another empty nx.Graph (that was then populated). The problem manifests much more clearly when trying to populate a directed graph instead and receiving an undirected graph in return!

In addition to fixing the bug, I added a backwards compatible flag (`is_directed=False)` to `from_file` such that users of directed graphs don't have to go the whole way to the full blown `from_dataset` just to use a directed graph.  The current behavior is maintained in that it defaults to an undirected graph, but users can now specifically request creation of a directed graph instead.

Closes #29