### PR TITLE
Fix call len call to get number of edges

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,8 +1,7 @@
 # Release Notes
-## 0.1.3
-- Fix bug when getting the length of edges when performing graph augmentations.
 ## 0.1.2
 - Rename `self_loop_augmentation` to `diagonal_augmentation` and use weighted degree to perform calculation instead of degree only.
+- Fix bug when getting the length of edges when performing graph augmentations.
 ## 0.1.1
 - [Issue 29](https://github.com/microsoft/topologic/issues/29) Fixed bug in `topologic.io.from_dataset` where an empty networkx graph object (Graph, DiGraph, etc) was being treated as if no networkx Graph object were provided at all.
 - Added `is_digraph` parameter to `topologic.io.from_file`. This parameter defaults to False for original behavior. Setting it to True will create a networkx DiGraph object instead.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,4 +1,6 @@
 # Release Notes
+## 0.1.3
+- Fix bug when getting the length of edges when performing graph augmentations.
 ## 0.1.2
 - Rename `self_loop_augmentation` to `diagonal_augmentation` and use weighted degree to perform calculation instead of degree only.
 ## 0.1.1

--- a/topologic/graph_augmentation.py
+++ b/topologic/graph_augmentation.py
@@ -85,7 +85,7 @@ def rank_edges(
     """
     assertions.assert_is_weighted_graph(graph, weight_column)
 
-    edge_count = len(graph.edges)
+    edge_count = len(graph.edges())
     edge_data = graph.edges(data=True)
     edges = np.array(
         list(


### PR DESCRIPTION
Fix a call to len which should be using the method. I believe .edges used to work in previous networkx versions but this is more correct.

Fixes #36 