### PR TITLE
Only skip unit test on MacOS and only on Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         flake8 ./topologic ./tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests topologic --doctest-modules
+        SKIP_TEST_35=true pytest -v tests topologic --doctest-modules
     - name: Generate docs with Sphinx
       run: |
         sphinx-build -W -a docs/ docs/_build/html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,9 @@ jobs:
         flake8 ./topologic ./tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        SKIP_TEST_35=true pytest -v tests topologic --doctest-modules
+        pytest -v tests topologic --doctest-modules
+      env:
+        SKIP_TEST_35: true
     - name: Generate docs with Sphinx
       run: |
         sphinx-build -W -a docs/ docs/_build/html

--- a/.github/workflows/validate_on_push.yml
+++ b/.github/workflows/validate_on_push.yml
@@ -34,7 +34,7 @@ jobs:
         flake8 ./topologic ./tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        SKIP_TEST_35=true pytest tests topologic --doctest-modules
+        SKIP_TEST_35=true pytest -v tests topologic --doctest-modules
     - name: Build with setuptools
       run: |
         python setup.py build sdist

--- a/.github/workflows/validate_on_push.yml
+++ b/.github/workflows/validate_on_push.yml
@@ -34,7 +34,9 @@ jobs:
         flake8 ./topologic ./tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        SKIP_TEST_35=true pytest -v tests topologic --doctest-modules
+        pytest -v tests topologic --doctest-modules
+      env:
+        SKIP_TEST_35: true
     - name: Build with setuptools
       run: |
         python setup.py build sdist

--- a/.github/workflows/validate_on_push.yml
+++ b/.github/workflows/validate_on_push.yml
@@ -34,7 +34,7 @@ jobs:
         flake8 ./topologic ./tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests topologic --doctest-modules
+        SKIP_TEST_35=true pytest tests topologic --doctest-modules
     - name: Build with setuptools
       run: |
         python setup.py build sdist

--- a/tests/embedding/test_laplacian_spectral_embedding.py
+++ b/tests/embedding/test_laplacian_spectral_embedding.py
@@ -63,7 +63,3 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
 
         np.testing.assert_array_equal(result.embedding, unpickled.embedding)
         np.testing.assert_array_equal(result.vertex_labels, unpickled.vertex_labels)
-
-
-def skip_35() -> bool:
-    return sys.platform.startswith('darwin') and os.getenv("SKIP_TEST_35", "false") == "true"

--- a/tests/embedding/test_laplacian_spectral_embedding.py
+++ b/tests/embedding/test_laplacian_spectral_embedding.py
@@ -5,7 +5,6 @@ import pickle
 import os
 import sys
 import unittest
-import warnings
 
 import networkx as nx
 import numpy as np

--- a/tests/embedding/test_laplacian_spectral_embedding.py
+++ b/tests/embedding/test_laplacian_spectral_embedding.py
@@ -34,6 +34,7 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
         self.assertListEqual(expected_label, labels)
 
     def test_laplacian_embedding_elbowcut_none(self):
+        print(f"{sys.platform} and {os.getenv('SKIP_TEST_35', 'false')}")
         if sys.platform.startswith('darwin') and os.getenv("SKIP_TEST_35", "false") == "true":
             message = 'Test not supported on Mac OS + Github Actions, see: ' \
                       'https://github.com/microsoft/topologic/issues/35'

--- a/tests/embedding/test_laplacian_spectral_embedding.py
+++ b/tests/embedding/test_laplacian_spectral_embedding.py
@@ -33,14 +33,11 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
         np.testing.assert_allclose(expected_matrix, matrix, rtol=1e-5)
         self.assertListEqual(expected_label, labels)
 
+    @unittest.skipIf(
+        sys.platform.startswith('darwin') and os.getenv("SKIP_TEST_35", "false") == "true",
+        "Test not supported on MacOS Github Actions, see: https://github.com/microsoft/topologic/issues/35"
+    )
     def test_laplacian_embedding_elbowcut_none(self):
-        print(f"{sys.platform} and {os.getenv('SKIP_TEST_35', 'false')}")
-        if sys.platform.startswith('darwin') and os.getenv("SKIP_TEST_35", "false") == "true":
-            message = 'Test not supported on Mac OS + Github Actions, see: ' \
-                      'https://github.com/microsoft/topologic/issues/35'
-            warnings.warn(message)
-            unittest.skip(message)
-
         graph = nx.Graph([('a', 'b', {'weight': 2.0}), ('b', 'c', {'weight': 2.0})])
         result = laplacian_embedding(
             graph,
@@ -67,3 +64,7 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
 
         np.testing.assert_array_equal(result.embedding, unpickled.embedding)
         np.testing.assert_array_equal(result.vertex_labels, unpickled.vertex_labels)
+
+
+def skip_35() -> bool:
+    return sys.platform.startswith('darwin') and os.getenv("SKIP_TEST_35", "false") == "true"

--- a/tests/embedding/test_laplacian_spectral_embedding.py
+++ b/tests/embedding/test_laplacian_spectral_embedding.py
@@ -2,12 +2,13 @@
 # Licensed under the MIT license.
 
 import pickle
+import os
 import sys
 import unittest
+import warnings
 
 import networkx as nx
 import numpy as np
-import pytest
 
 from topologic.embedding import laplacian_embedding
 
@@ -33,8 +34,11 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
         self.assertListEqual(expected_label, labels)
 
     def test_laplacian_embedding_elbowcut_none(self):
-        if sys.platform.startswith('darwin'):
-            pytest.skip('Test not supported on Mac OS')
+        if sys.platform.startswith('darwin') and os.getenv("SKIP_TEST_35", "false") == "true":
+            message = 'Test not supported on Mac OS + Github Actions, see: ' \
+                      'https://github.com/microsoft/topologic/issues/35'
+            warnings.warn(message)
+            unittest.skip(message)
 
         graph = nx.Graph([('a', 'b', {'weight': 2.0}), ('b', 'c', {'weight': 2.0})])
         result = laplacian_embedding(


### PR DESCRIPTION
This commit Closes #35 

We still don't know why the unit test `test_laplacian_embedding_elbowcut_none` fails on the MacOS Github Action instances, but not on any other MacOS system that we've tried.  I tried replicating the error using Python 3.6.10, Python 3.7.7, and Python 3.8.2 on MacOS 10.15.4.  @Nyecarr was able to use another developer's machine and couldn't replicate it either.

This fix addresses the issue by effectively ignoring it as we can't reproduce it elsewhere, but it took steps to make the test be skipped only on Github Actions, only when using the .github/workflows/validate_on_push.yml workflow file, and only as long as the SKIP_TEST_35=true environment variable is used when running the test.

This means that developer/user testers of topologic with MacOS will still run this unit test, and we can also create a new branch to disable this flag and continue testing topologic + Github Actions on MacOS in an attempt to see when, or if, this is fixed (since it doesn't seem to be related to us so much as Github's CI instances).