### PR TITLE
Users identified unexpected behavior well beyond our initial assumpti…

### DIFF
--- a/tests/partition/test_modularity.py
+++ b/tests/partition/test_modularity.py
@@ -78,8 +78,4 @@ class TestModularity(unittest.TestCase):
         self.assertSetEqual(set(components.keys()), set(partitions.values()))
         self.assertEqual(0, components[partition_count + 1])
 
-        # the following test is not super inspiring. I am not a floating point number specialist, but as far as I can
-        # tell it's because networkx.Graph().degree() returns 2 times the edge weight for each value, which
-        # we then divide by 2.0 immediately and sum, whereas in our version we don't do this step.
-        # aside from (not) doing that, the only other difference is using math.pow instead of `**`.
-        np.testing.assert_almost_equal(community_modularity, total_modularity, decimal=3)
+        np.testing.assert_almost_equal(community_modularity, total_modularity, decimal=8)

--- a/topologic/partition/modularity.py
+++ b/topologic/partition/modularity.py
@@ -79,22 +79,20 @@ def modularity(
 
 
 def _modularity_component(
-    degree_sum_within_community: float,
-    degree_sum: float,
-    total_network_edge_weight: float,
+    intra_community_degree: float,
+    total_community_degree: float,
+    network_degree_sum: float,
     resolution: float
 ) -> float:
-    degree_within_community_ratio = degree_sum_within_community / total_network_edge_weight
-    community_degree_ratio = math.pow(degree_sum / (2.0 * total_network_edge_weight), 2.0)
-
-    return degree_within_community_ratio - resolution * community_degree_ratio
+    community_degree_ratio = math.pow(total_community_degree, 2.0) / (2.0 * network_degree_sum)
+    return (intra_community_degree - resolution * community_degree_ratio) / (2.0 * network_degree_sum)
 
 
 def modularity_components(
     graph: nx.Graph,
     partitions: Dict[Any, int],
     weight_attribute: str = "weight",
-    resolution: float = 1.0
+    resolution: float = 1.0,
 ) -> Dict[int, float]:
     """
     Given an undirected, weighted graph and a community partition dictionary, calculates a modularity quantum for each
@@ -127,10 +125,11 @@ def modularity_components(
         neighbor_community = partitions[neighbor_vertex]
         if vertex_community == neighbor_community:
             if vertex == neighbor_vertex:
-                degree_sums_within_community[vertex_community] += weight * 2.0
-            else:
                 degree_sums_within_community[vertex_community] += weight
-        degree_sums_for_community[vertex_community] += weight * 2.0
+            else:
+                degree_sums_within_community[vertex_community] += weight * 2.0
+        degree_sums_for_community[vertex_community] += weight
+        degree_sums_for_community[neighbor_community] += weight
         total_edge_weight += weight
 
     return {comm: _modularity_component(


### PR DESCRIPTION
…on of cascading floating point deviations. It never sat right that we were only accurate in our test within 3 decimal places (as can be seen by the comment in our unit test), but it also seemed plausible at the time.

Since then we had new data showing that it was even worse than we thought and far less likely to be aggregating floating point deviations.

Ultimately the issue was because I wrongly assumed that networkx Graph objects would return both edges in an undirected graph (or rather, it would treat it like a directed graph but with an identical/mirror relationship). As such we weren't accumulating values for the destination/target vertex, and our calculations were far, far from what they should have been.

This is now correct and our unit tests show exact parity with the python-louvain library's community.modularity function (unit test has been left to use numpy.testing.assert_almost_equal, but now precision is out to 8 decimal places.)

Closes #47