### PR TITLE
Union largest connected component omni strategy

### DIFF
--- a/tests/embedding/test_omnibus_embedding.py
+++ b/tests/embedding/test_omnibus_embedding.py
@@ -115,7 +115,7 @@ class TestOmnibusEmbedding(unittest.TestCase):
             )
         )
 
-    def test_med_cohort_graph_generates_embedding(self):
+    def test_barbell_graph_generates_embedding(self):
         graph = nx.barbell_graph(10, 2)
 
         for edge in graph.edges():

--- a/tests/embedding/test_omnibus_embedding.py
+++ b/tests/embedding/test_omnibus_embedding.py
@@ -115,6 +115,35 @@ class TestOmnibusEmbedding(unittest.TestCase):
             )
         )
 
+    def test_union_lcc_returns_expected_shape(self):
+        first = nx.Graph()
+        first.add_edge(0, 1, weight=1)
+        first.add_edge(1, 2, weight=1)
+        # node 3 and 4 will exist in the union LCC as there is an edge that connects them to the
+        # LCC of the union of all edges in first, second
+        first.add_edge(3, 4, weight=1)
+        # node 5 will not appear in the embedding as it is not in the LCC of the union edges
+        first.add_edge(5, 5, weight=1)
+
+        second = nx.Graph()
+        second.add_edge(0, 1, weight=1)
+        second.add_edge(1, 2, weight=1)
+        second.add_edge(3, 1, weight=1)
+
+        result = tc.embedding.omnibus_embedding(
+            [first, second]
+        )
+
+        self.assertIsNotNone(result)
+
+        for containers in result:
+            self.assertEqual(len(containers[0].embedding.shape), len(containers[1].embedding.shape))
+            self.assertEqual(len(containers[0].vertex_labels), len(containers[1].vertex_labels))
+
+            self.assertTrue(3 in containers[0].vertex_labels)
+            self.assertTrue(4 in containers[0].vertex_labels)
+            self.assertTrue(5 not in containers[0].vertex_labels)
+
     def test_barbell_graph_generates_embedding(self):
         graph = nx.barbell_graph(10, 2)
 
@@ -133,7 +162,7 @@ class TestOmnibusEmbedding(unittest.TestCase):
             self.assertEqual(len(containers[0].embedding.shape), len(containers[1].embedding.shape))
             self.assertEqual(len(containers[0].vertex_labels), len(containers[1].vertex_labels))
 
-    def test_med_cohort_graph_generates_laplacian_embedding(self):
+    def test_barbell_graph_generates_laplacian_embedding(self):
         graph = nx.barbell_graph(10, 2)
 
         for edge in graph.edges():

--- a/topologic/embedding/omnibus_embedding.py
+++ b/topologic/embedding/omnibus_embedding.py
@@ -34,7 +34,8 @@ def omnibus_embedding(
     There should be exactly the same number of nodes in each graph with exactly the same labels. The list of graphs
     should represent a time series and should be in an order such that time is continuous through the list of graphs.
 
-    If the labels differ between each pair of graphs, then those nodes will _not_ be found in the resulting embedding.
+    If the labels differ between each pair of graphs, then those nodes will only be found in the resulting embedding
+    if they exist in the largest connected component of the union of all edges across all graphs in the time series.
 
     :param List[networkx.Graph] graphs: A list of graphs that will be used to generate the omnibus embedding. Each graph
         should have exactly the same vertices as each of the other graphs. The order of the graphs in the list matter.
@@ -221,14 +222,15 @@ def _get_unstacked_embeddings(embedding, graphs, labels):
 
 def _get_adjacency_matrices(graphs):
     matrices = []
-    labels = []
+    labels = set()
     for graph in graphs:
         sorted_nodes = sorted(graph.nodes())
         matrices.append(nx.to_scipy_sparse_matrix(graph, nodelist=sorted_nodes))
 
         for node in sorted_nodes:
-            labels.append(node)
-    return labels, matrices
+            labels.add(node)
+
+    return list(labels), matrices
 
 
 def _get_laplacian_matrices(graphs):


### PR DESCRIPTION
Previously we were limiting the nodes included during the omnibus embedding to be the set of nodes in the intersection of the largest connected components between each pair of graphs passed as an argument.

With some joint research with JHU we have developed a new strategy that allows us to embed more nodes. To accomplish this, we:

1. Create a graph that contains the union of all edges across all time series graphs
2. Calculate the LCC of that union graph
3. For each time series graph, assert that:
    a. Remove all nodes not contained in the vertex set of the LCC union graph
    b. Add all nodes in the LCC union graph to the graph as an isolate (no edges)
        - This is important as it allows us to maintain the correct shape of each time series graph's adjacency matrix

I added a test called `test_union_lcc_returns_expected_shape` that hopefully illuminates the exact scenario.