### PR TITLE
Omnibus string node ids sorting fix

### DIFF
--- a/topologic/embedding/omnibus_embedding.py
+++ b/topologic/embedding/omnibus_embedding.py
@@ -231,7 +231,7 @@ def _get_adjacency_matrices(graphs):
         for node in sorted_nodes:
             labels.add(node)
 
-    return list(labels), matrices
+    return sorted(list(labels)), matrices
 
 
 def _get_laplacian_matrices(graphs):


### PR DESCRIPTION
When a graph's nodes contain strings instead of ints the labels returned were out of order.