### PR TITLE
Release a deprecated library for our last release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,21 +23,6 @@ jobs:
       run: |
         python .github/build/set_version.py > topologic/version/version.txt
         cat topologic/version/version.txt
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 ./topologic ./tests --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 ./topologic ./tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest -v tests topologic --doctest-modules
-      env:
-        SKIP_TEST_35: true
-    - name: Generate docs with Sphinx
-      run: |
-        sphinx-build -W -a docs/ docs/_build/html
     - name: Build with setuptools
       run: |
         python setup.py build sdist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,6 @@ jobs:
       run: |
         python .github/build/set_version.py > topologic/version/version.txt
         cat topologic/version/version.txt
-    - name: Type check with mypy
-      run: |
-        mypy ./topologic
-        mypy ./tests
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/validate_on_push.yml
+++ b/.github/workflows/validate_on_push.yml
@@ -21,10 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
-    - name: Type check with mypy
-      run: |
-        mypy ./topologic
-        mypy ./tests
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/validate_on_push.yml
+++ b/.github/workflows/validate_on_push.yml
@@ -24,6 +24,3 @@ jobs:
     - name: Build with setuptools
       run: |
         python setup.py build sdist
-    - name: Generate docs with Sphinx
-      run: |
-        sphinx-build -W -a docs/ docs/_build/html

--- a/.github/workflows/validate_on_push.yml
+++ b/.github/workflows/validate_on_push.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: [3.6, 3.7, 3.8]
+        python_version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/validate_on_push.yml
+++ b/.github/workflows/validate_on_push.yml
@@ -21,18 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 ./topologic ./tests --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 ./topologic ./tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest -v tests topologic --doctest-modules
-      env:
-        SKIP_TEST_35: true
     - name: Build with setuptools
       run: |
         python setup.py build sdist

--- a/topologic/__init__.py
+++ b/topologic/__init__.py
@@ -20,6 +20,10 @@ from . import statistics
 from . import embedding
 from . import partition
 
+import warnings
+
+warnings.warn("The python library `topologic` has been deprecated in favor of `graspologic` in PyPI. Please update your consuming code.  Perhaps you meant the library `topologicpy` https://pypi.org/project/topologicpy/ ?", DeprecationWarning)
+
 __all__ = [
     'connected_components_generator',
     'DialectException',

--- a/topologic/__init__.py
+++ b/topologic/__init__.py
@@ -22,7 +22,7 @@ from . import partition
 
 import warnings
 
-warnings.warn("The python library `topologic` has been deprecated in favor of `graspologic` in PyPI. Please update your consuming code.  Perhaps you meant the library `topologicpy` https://pypi.org/project/topologicpy/ ?", DeprecationWarning)
+warnings.warn("The python library `topologic` has been deprecated in favor of `graspologic` in PyPI. Please update your consuming code.  Perhaps you meant the library `topologicpy` https://pypi.org/project/topologicpy/ ?", UserWarning)
 
 __all__ = [
     'connected_components_generator',

--- a/topologic/version/version.py
+++ b/topologic/version/version.py
@@ -10,7 +10,7 @@ __all__: List[str] = ["version", "name"]
 name = "topologic"
 
 # manually updated
-__semver = "0.1.8"
+__semver = "0.1.9"
 #  full version (may be same as __semver on release)
 __version_file = "version.txt"
 


### PR DESCRIPTION
Publishing a new library that deprecates topologic in favor of graspologic and endeavours to redirect any new users toward the actually living `topologicpy` by https://topologic.app 